### PR TITLE
arch migrators

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -32,6 +32,24 @@ jobs:
       osx_64_mpiopenmpipython3.9.____cpython:
         CONFIG: osx_64_mpiopenmpipython3.9.____cpython
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpimpichpython3.10.____cpython:
+        CONFIG: osx_arm64_mpimpichpython3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpimpichpython3.8.____cpython:
+        CONFIG: osx_arm64_mpimpichpython3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpimpichpython3.9.____cpython:
+        CONFIG: osx_arm64_mpimpichpython3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpiopenmpipython3.10.____cpython:
+        CONFIG: osx_arm64_mpiopenmpipython3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpiopenmpipython3.8.____cpython:
+        CONFIG: osx_arm64_mpiopenmpipython3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpiopenmpipython3.9.____cpython:
+        CONFIG: osx_arm64_mpiopenmpipython3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_aarch64_mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.10.____cpython.yaml
@@ -1,0 +1,46 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+boost_cpp:
+- 1.74.0
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+hdf5:
+- 1.12.1
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.10.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_mpimpichpython3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.7.____cpython.yaml
@@ -1,0 +1,46 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+boost_cpp:
+- 1.74.0
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+hdf5:
+- 1.12.1
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.7.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_mpimpichpython3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.8.____cpython.yaml
@@ -1,0 +1,46 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+boost_cpp:
+- 1.74.0
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+hdf5:
+- 1.12.1
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.8.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_mpimpichpython3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.9.____cpython.yaml
@@ -1,0 +1,46 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+boost_cpp:
+- 1.74.0
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+hdf5:
+- 1.12.1
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.9.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpython.yaml
@@ -1,0 +1,46 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+boost_cpp:
+- 1.74.0
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+hdf5:
+- 1.12.1
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.10.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.7.____cpython.yaml
@@ -1,0 +1,46 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+boost_cpp:
+- 1.74.0
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+hdf5:
+- 1.12.1
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.7.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.8.____cpython.yaml
@@ -1,0 +1,46 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+boost_cpp:
+- 1.74.0
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+hdf5:
+- 1.12.1
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.8.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpython.yaml
@@ -1,0 +1,46 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+boost_cpp:
+- 1.74.0
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+hdf5:
+- 1.12.1
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.9.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpython.yaml
@@ -1,0 +1,42 @@
+boost_cpp:
+- 1.74.0
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+hdf5:
+- 1.12.1
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.10.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_mpimpichpython3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.7.____cpython.yaml
@@ -1,0 +1,42 @@
+boost_cpp:
+- 1.74.0
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+hdf5:
+- 1.12.1
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.7.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_mpimpichpython3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.8.____cpython.yaml
@@ -1,0 +1,42 @@
+boost_cpp:
+- 1.74.0
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+hdf5:
+- 1.12.1
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.8.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpython.yaml
@@ -1,0 +1,42 @@
+boost_cpp:
+- 1.74.0
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+hdf5:
+- 1.12.1
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.9.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpython.yaml
@@ -1,0 +1,42 @@
+boost_cpp:
+- 1.74.0
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+hdf5:
+- 1.12.1
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.10.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.7.____cpython.yaml
@@ -1,0 +1,42 @@
+boost_cpp:
+- 1.74.0
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+hdf5:
+- 1.12.1
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.7.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.8.____cpython.yaml
@@ -1,0 +1,42 @@
+boost_cpp:
+- 1.74.0
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+hdf5:
+- 1.12.1
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.8.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpython.yaml
@@ -1,0 +1,42 @@
+boost_cpp:
+- 1.74.0
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+hdf5:
+- 1.12.1
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.9.* *_cpython
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'
+target_platform:
+- linux-ppc64le

--- a/.ci_support/osx_arm64_mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.10.____cpython.yaml
@@ -1,0 +1,38 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+boost_cpp:
+- 1.74.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+hdf5:
+- 1.12.1
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.10.* *_cpython
+target_platform:
+- osx-arm64

--- a/.ci_support/osx_arm64_mpimpichpython3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.8.____cpython.yaml
@@ -1,0 +1,38 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+boost_cpp:
+- 1.74.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+hdf5:
+- 1.12.1
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.8.* *_cpython
+target_platform:
+- osx-arm64

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpython.yaml
@@ -1,0 +1,38 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+boost_cpp:
+- 1.74.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+hdf5:
+- 1.12.1
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.9.* *_cpython
+target_platform:
+- osx-arm64

--- a/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpython.yaml
@@ -1,0 +1,38 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+boost_cpp:
+- 1.74.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+hdf5:
+- 1.12.1
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.10.* *_cpython
+target_platform:
+- osx-arm64

--- a/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpython.yaml
@@ -1,0 +1,38 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+boost_cpp:
+- 1.74.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+hdf5:
+- 1.12.1
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.8.* *_cpython
+target_platform:
+- osx-arm64

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpython.yaml
@@ -1,0 +1,38 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+boost_cpp:
+- 1.74.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+hdf5:
+- 1.12.1
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+ptscotch:
+- 6.0.9
+python:
+- 3.9.* *_cpython
+target_platform:
+- osx-arm64

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -42,6 +42,9 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -56,6 +56,10 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
+
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,97 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: generic
+
+
+
+matrix:
+  include:
+    - env: CONFIG=linux_aarch64_mpimpichpython3.10.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+      os: linux
+      arch: arm64
+      dist: focal
+
+    - env: CONFIG=linux_aarch64_mpimpichpython3.7.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+      os: linux
+      arch: arm64
+      dist: focal
+
+    - env: CONFIG=linux_aarch64_mpimpichpython3.8.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+      os: linux
+      arch: arm64
+      dist: focal
+
+    - env: CONFIG=linux_aarch64_mpimpichpython3.9.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+      os: linux
+      arch: arm64
+      dist: focal
+
+    - env: CONFIG=linux_aarch64_mpiopenmpipython3.10.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+      os: linux
+      arch: arm64
+      dist: focal
+
+    - env: CONFIG=linux_aarch64_mpiopenmpipython3.7.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+      os: linux
+      arch: arm64
+      dist: focal
+
+    - env: CONFIG=linux_aarch64_mpiopenmpipython3.8.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+      os: linux
+      arch: arm64
+      dist: focal
+
+    - env: CONFIG=linux_aarch64_mpiopenmpipython3.9.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+      os: linux
+      arch: arm64
+      dist: focal
+
+    - env: CONFIG=linux_ppc64le_mpimpichpython3.10.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+      dist: focal
+
+    - env: CONFIG=linux_ppc64le_mpimpichpython3.7.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+      dist: focal
+
+    - env: CONFIG=linux_ppc64le_mpimpichpython3.8.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+      dist: focal
+
+    - env: CONFIG=linux_ppc64le_mpimpichpython3.9.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+      dist: focal
+
+    - env: CONFIG=linux_ppc64le_mpiopenmpipython3.10.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+      dist: focal
+
+    - env: CONFIG=linux_ppc64le_mpiopenmpipython3.7.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+      dist: focal
+
+    - env: CONFIG=linux_ppc64le_mpiopenmpipython3.8.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+      dist: focal
+
+    - env: CONFIG=linux_ppc64le_mpiopenmpipython3.9.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+      dist: focal
+
+script:
+  - export CI=travis
+  - export GIT_BRANCH="$TRAVIS_BRANCH"
+  - export FEEDSTOCK_NAME=$(basename ${TRAVIS_REPO_SLUG})
+  - if [[ "${TRAVIS_PULL_REQUEST:-}" == "false" ]]; then export IS_PR_BUILD="False"; else export IS_PR_BUILD="True"; fi
+
+
+  - if [[ ${PLATFORM} =~ .*linux.* ]]; then CONDA_FORGE_DOCKER_RUN_ARGS="--network=host --security-opt=seccomp=unconfined" ./.scripts/run_docker_build.sh; fi

--- a/README.md
+++ b/README.md
@@ -21,7 +21,14 @@ Current build status
 ====================
 
 
-<table>
+<table><tr>
+    <td>Travis</td>
+    <td>
+      <a href="https://app.travis-ci.com/conda-forge/fenics-dolfinx-feedstock">
+        <img alt="linux" src="https://img.shields.io/travis/com/conda-forge/fenics-dolfinx-feedstock/main.svg?label=Linux">
+      </a>
+    </td>
+  </tr>
     
   <tr>
     <td>Azure</td>
@@ -91,6 +98,118 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_mpimpichpython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_mpimpichpython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpimpichpython3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_mpimpichpython3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpimpichpython3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_mpimpichpython3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpimpichpython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_mpimpichpython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpiopenmpipython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_mpiopenmpipython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpiopenmpipython3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_mpiopenmpipython3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpiopenmpipython3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_mpiopenmpipython3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpiopenmpipython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_mpiopenmpipython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpimpichpython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_mpimpichpython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpimpichpython3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_mpimpichpython3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpimpichpython3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_mpimpichpython3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpimpichpython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_mpimpichpython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpiopenmpipython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_mpiopenmpipython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpiopenmpipython3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_mpiopenmpipython3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpiopenmpipython3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_mpiopenmpipython3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpiopenmpipython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_mpiopenmpipython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_mpimpichpython3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
@@ -144,6 +263,48 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=osx&configuration=osx_64_mpiopenmpipython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpimpichpython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_mpimpichpython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpimpichpython3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_mpimpichpython3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpimpichpython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_mpimpichpython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpiopenmpipython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_mpiopenmpipython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpiopenmpipython3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_mpiopenmpipython3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpiopenmpipython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=16326&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fenics-dolfinx-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_mpiopenmpipython3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,4 +1,10 @@
+build_platform:
+  osx_arm64: osx_64
+conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main
-conda_forge_output_validation: true
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/recipe/build-dolfinx.sh
+++ b/recipe/build-dolfinx.sh
@@ -3,4 +3,10 @@ if [[ "$target_platform" == "osx-64" ]]; then
   export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 fi
 
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-0}" == "1" ]]; then
+  # needed for cross-compile openmpi
+  export OPAL_CC="$CC"
+  export OPAL_PREFIX="$PREFIX"
+fi
+
 $PYTHON -m pip install -vv --no-deps ./python

--- a/recipe/build-libdolfinx.sh
+++ b/recipe/build-libdolfinx.sh
@@ -4,6 +4,7 @@ if [[ "$target_platform" == "osx-64" ]]; then
 fi
 
 cmake \
+  ${CMAKE_ARGS} \
   -DCMAKE_INSTALL_PREFIX=$PREFIX \
   -B build \
   cpp

--- a/recipe/build-libdolfinx.sh
+++ b/recipe/build-libdolfinx.sh
@@ -3,6 +3,10 @@ if [[ "$target_platform" == "osx-64" ]]; then
   export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 fi
 
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-0}" == "1" ]]; then
+  CMAKE_ARGS="${CMAKE_ARGS} -DDOLFINX_SKIP_BUILD_TESTS=1"
+fi
+
 cmake \
   ${CMAKE_ARGS} \
   -DCMAKE_INSTALL_PREFIX=$PREFIX \

--- a/recipe/build-libdolfinx.sh
+++ b/recipe/build-libdolfinx.sh
@@ -5,7 +5,12 @@ fi
 
 if [[ "${CONDA_BUILD_CROSS_COMPILATION:-0}" == "1" ]]; then
   CMAKE_ARGS="${CMAKE_ARGS} -DDOLFINX_SKIP_BUILD_TESTS=1"
+  # needed for cross-compile openmpi
+  export OPAL_CC="$CC"
+  export OPAL_PREFIX="$PREFIX"
 fi
+
+
 
 cmake \
   ${CMAKE_ARGS} \

--- a/recipe/cmake-args-python.patch
+++ b/recipe/cmake-args-python.patch
@@ -1,0 +1,26 @@
+From 7a0dc443a6267f2b46226b5339693af06db9b454 Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Sat, 4 Jun 2022 10:49:16 +0200
+Subject: [PATCH] disable parallel builds
+
+add CMAKE_ARGS for cross-compilation
+---
+ python/setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/python/setup.py b/python/setup.py
+index 52f26bc11d..f0c42d7e95 100644
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -48,7 +48,9 @@ class CMakeBuild(build_ext):
+         cfg = 'Debug' if self.debug else 'Release'
+         build_args = ['--config', cfg]
+         cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
+         build_args += ['--', '-j3']
++        import shlex
++        cmake_args += shlex.split(os.environ["CMAKE_ARGS"])
+
+         env = os.environ.copy()
+         import pybind11
+--
+2.35.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 68dcf29a26c750fcea5e02d8d58411e3b054313c3bf6fcbc1d0f08dd2851117f
   patches:
     - "0001-cpp-test-remove-extra-semicolon.patch"
+    - "no-parallel-python-cmake.patch"  # [ target_platform == "linux-aarch64" ]
 build:
   number: 6
   skip: true  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,8 +46,7 @@ outputs:
         - parmetis
         - ptscotch
         - petsc
-        # slepc not yet packaged for mac-arm
-        - slepc  # [not (osx and arm64)]
+        - slepc
         - xtensor
         - fenics-libbasix 0.4.*
         - fenics-ufcx 0.4.*
@@ -57,7 +56,7 @@ outputs:
         - hdf5
         - ptscotch
         - petsc
-        - slepc  # [not (osx and arm64)]
+        - slepc
         - fenics-libbasix
         # these don't have run_exports
         # but are needed at runtime for code generation
@@ -102,8 +101,8 @@ outputs:
         - mpi4py
         - petsc
         - petsc4py
-        - slepc  # [not (osx and arm64)]
-        - slepc4py  # [not (osx and arm64)]
+        - slepc
+        - slepc4py
       run:
         - {{ compiler("cxx") }}  # [linux]
         - python
@@ -111,7 +110,7 @@ outputs:
         - mpi4py
         - numpy
         - petsc4py
-        - slepc4py  # [not (osx and arm64)]
+        - slepc4py
         - fenics-basix ==0.4.*,>=0.4.1
         - fenics-ffcx ==0.4.*,>=0.4.2
         - fenics-ufl ==2022.1.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 68dcf29a26c750fcea5e02d8d58411e3b054313c3bf6fcbc1d0f08dd2851117f
   patches:
     - "0001-cpp-test-remove-extra-semicolon.patch"
-    - "no-parallel-python-cmake.patch"  # [ target_platform == "linux-aarch64" ]
+    - "no-parallel-python-cmake.patch"  # [ target_platform == "linux-aarch64" or target_platform == "linux-ppc64le" ]
 build:
   number: 6
   skip: true  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
   patches:
     - "0001-cpp-test-remove-extra-semicolon.patch"
     - "no-parallel-python-cmake.patch"  # [ target_platform == "linux-aarch64" or target_platform == "linux-ppc64le" ]
+    - "cmake-args-python.patch"  # [ target_platform != build_platform ]
 build:
   number: 6
   skip: true  # [win]
@@ -35,6 +36,7 @@ outputs:
         - {{ pin_subpackage("fenics-libdolfinx", max_pin="x.x.x") }}
     requirements:
       build:
+        - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         - cmake
         - make
@@ -82,6 +84,7 @@ outputs:
     script: build-dolfinx.sh
     requirements:
       build:
+        - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         - cmake
         - make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ outputs:
         - cmake
         - make
         - pkg-config
+        - {{ mpi }}  # [mpi == 'openmpi' and build_platform != target_platform]
       host:
         - {{ mpi }}
         - adios2
@@ -88,6 +89,7 @@ outputs:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - pybind11                               # [build_platform != target_platform]
+        - {{ mpi }}  # [mpi == 'openmpi' and build_platform != target_platform]
       host:
         - {{ mpi }}
         - boost-cpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,8 @@ outputs:
   - name: fenics-libdolfinx
     script: build-libdolfinx.sh
     build:
+      skip_compile_pyc:
+        - "*"  # [build_platform != target_platform]
       run_exports:
         - {{ pin_subpackage("fenics-libdolfinx", max_pin="x.x.x") }}
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   patches:
     - "0001-cpp-test-remove-extra-semicolon.patch"
 build:
-  number: 5
+  number: 6
   skip: true  # [win]
   script_env:
     - OMPI_ALLOW_RUN_AS_ROOT=1
@@ -83,6 +83,9 @@ outputs:
         - cmake
         - make
         - pkg-config
+        - python                                 # [build_platform != target_platform]
+        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+        - pybind11                               # [build_platform != target_platform]
       host:
         - {{ mpi }}
         - boost-cpp

--- a/recipe/no-parallel-python-cmake.patch
+++ b/recipe/no-parallel-python-cmake.patch
@@ -1,0 +1,26 @@
+From 7a0dc443a6267f2b46226b5339693af06db9b454 Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Sat, 4 Jun 2022 10:49:16 +0200
+Subject: [PATCH] disable parallel builds
+
+maybe this is hitting memory issues on travis aarch64
+---
+ python/setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/python/setup.py b/python/setup.py
+index 52f26bc11d..f0c42d7e95 100644
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -48,7 +48,7 @@ class CMakeBuild(build_ext):
+         cfg = 'Debug' if self.debug else 'Release'
+         build_args = ['--config', cfg]
+         cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
+-        build_args += ['--', '-j3']
++        # build_args += ['--', '-j3']
+ 
+         env = os.environ.copy()
+         import pybind11
+-- 
+2.35.3
+


### PR DESCRIPTION
closes #8

the migrator seems to think this depends on the fenics recipe, presumably because fenics-ufl _used_ to be published from there, so applying this one by hand