### PR TITLE
use ignore_run_exports_from

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.4.1" %}
 {% set extra = "" %}
 
-{% set build = 8 %}
+{% set build = 9 %}
 {% if scalar == "real" %}
 {%   set build = build + 100 %}
 {% endif %}
@@ -41,7 +41,7 @@ outputs:
       run_exports:
         - {{ pin_subpackage("fenics-libdolfinx", max_pin="x.x.x") }}
         - petsc * {{ scalar }}_*
-      ignore_run_exports:
+      ignore_run_exports_from:
         - python
     requirements:
       build:


### PR DESCRIPTION
- run_exports specifies which package pins should be ignored (i.e. ignore dependency on python, exported from anything)
- run_exports_from specifies which package's exported pins should be ignored (ignore dependencies on any package, exported by python)

avoids direct python-abi dependency in libdolfinx, since python exports _both_ python and python-abi

transitive dependency still exists in adios until it splits (#15)
