### PR TITLE
petsc 3.18 migration

### DIFF
--- a/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_mpimpichpython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.8.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -29,9 +29,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -45,9 +45,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -29,9 +29,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -45,9 +45,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
@@ -29,9 +29,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -45,9 +45,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_mpimpichpython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.8.____cpythonscalarreal.yaml
@@ -29,9 +29,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -45,9 +45,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -29,9 +29,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -45,9 +45,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -29,9 +29,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -45,9 +45,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -29,9 +29,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -45,9 +45,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -29,9 +29,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -45,9 +45,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
@@ -29,9 +29,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -45,9 +45,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
@@ -29,9 +29,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -45,9 +45,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -29,9 +29,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -45,9 +45,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -29,9 +29,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -45,9 +45,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.8.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.8.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.8.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/migrations/petsc318.yaml
+++ b/.ci_support/migrations/petsc318.yaml
@@ -1,0 +1,13 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+migrator_ts: 1675950135.195193
+petsc:
+  - '3.18'
+petsc4py:
+  - '3.18'
+slepc:
+  - '3.18'
+slepc4py:
+  - '3.18'

--- a/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_mpimpichpython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.8.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_mpimpichpython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.8.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -25,9 +25,9 @@ mpich:
 openmpi:
 - '4'
 petsc:
-- '3.17'
+- '3.18'
 petsc4py:
-- '3.17'
+- '3.18'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -41,9 +41,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.17'
+- '3.18'
 slepc4py:
-- '3.17'
+- '3.18'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@
 {% set major_minor = version.rsplit(".", 1)[0] %}
 {% set ufl_version = "2023.1" %}
 
-{% set build = 3 %}
+{% set build = 4 %}
 {% if scalar == "real" %}
 {%   set build = build + 100 %}
 {% endif %}


### PR DESCRIPTION
avoid waiting for https://github.com/conda-forge/fenics-feedstock/pull/175, which is treated as upstream, even though it isn't (probably because of fenics-ufl)