### PR TITLE
Test gmsh

### DIFF
--- a/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/linux_64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/linux_64_mpimpichpython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.8.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/linux_64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/linux_64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -40,6 +40,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -40,6 +40,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/linux_aarch64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
@@ -40,6 +40,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/linux_aarch64_mpimpichpython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.8.____cpythonscalarreal.yaml
@@ -40,6 +40,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -40,6 +40,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -40,6 +40,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -40,6 +40,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -40,6 +40,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
@@ -40,6 +40,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
@@ -40,6 +40,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -40,6 +40,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -40,6 +40,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.8.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.8.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.8.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/osx_64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/osx_64_mpimpichpython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.8.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/osx_64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/osx_64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/osx_arm64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/osx_arm64_mpimpichpython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.8.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.10.* *_cpython
 scalar:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.8.* *_cpython
 scalar:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -36,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 ptscotch:
 - 6.0.9
+pybind11_abi:
+- '4'
 python:
 - 3.9.* *_cpython
 scalar:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -42,6 +42,14 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 source run_conda_forge_build_setup
 
+
+# Install the yum requirements defined canonically in the
+# "recipe/yum_requirements.txt" file. After updating that file,
+# run "conda smithy rerender" and this line will be updated
+# automatically.
+/usr/bin/sudo -n yum install -y mesa-libGL
+
+
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -147,6 +147,7 @@ outputs:
       requires:
         - pip
         - pytest >=6
+        - python-gmsh
 
 about:
   home: https://fenicsproject.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@
 {% set major_minor = version.rsplit(".", 1)[0] %}
 {% set ufl_version = "2023.1" %}
 
-{% set build = 4 %}
+{% set build = 5 %}
 {% if scalar == "real" %}
 {%   set build = build + 100 %}
 {% endif %}
@@ -118,6 +118,7 @@ outputs:
         - setuptools >=58
         - wheel
         - pybind11
+        - pybind11-abi
         - mpi4py
         - petsc * {{ scalar }}_*
         - petsc4py

--- a/recipe/test_dolfinx.py
+++ b/recipe/test_dolfinx.py
@@ -1,11 +1,13 @@
 import os
 
-import numpy as np
-from petsc4py.PETSc import ScalarType
-import pytest
-
 import dolfinx
+import gmsh
+import numpy as np
+import pytest
 from dolfinx.cpp import common
+from dolfinx.io import gmshio
+from mpi4py import MPI
+from petsc4py.PETSc import ScalarType
 
 
 def test_petsc_scalar():
@@ -28,3 +30,20 @@ def test_petsc_scalar():
 )
 def test_has(feature):
     assert getattr(common, f"has_{feature}")
+
+
+def test_gmshio():
+    # meshing example taken from https://jsdokken.com/dolfinx-tutorial/chapter1/membrane_code.html
+    gmsh.initialize()
+    membrane = gmsh.model.occ.addDisk(0, 0, 0, 1, 1)
+    gmsh.model.occ.synchronize()
+    gdim = 2
+    gmsh.model.addPhysicalGroup(gdim, [membrane], 1)
+    gmsh.model.mesh.generate(gdim)
+
+    gmsh_model_rank = 0
+    mesh_comm = MPI.COMM_WORLD
+    domain, cell_markers, facet_markers = gmshio.model_to_mesh(
+        gmsh.model, mesh_comm, gmsh_model_rank, gdim=2
+    )
+    gmsh.finalize()

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,0 +1,1 @@
+mesa-libGL


### PR DESCRIPTION
No change to the package so no build number update. I believe this would have caught failures due to the compiler mismatch with basix.

Should fail until https://github.com/conda-forge/fenics-basix-feedstock/pull/11 is out

