### PR TITLE
exercise pyvista in package tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -159,7 +159,9 @@ outputs:
       requires:
         - pip
         - pytest >=6
+        # make sure we're compatible with common but not required packages
         - python-gmsh
+        - pyvista
         # linux-aarch64 getting old gmsh with missing cairo
         # unclear what pin is holding it back
         - cairo  # [linux and aarch64]

--- a/recipe/test_dolfinx.py
+++ b/recipe/test_dolfinx.py
@@ -4,7 +4,6 @@ import dolfinx  # noqa
 import gmsh
 import numpy as np
 import pytest
-import pyvista
 from dolfinx.fem import Function, FunctionSpace
 from dolfinx.mesh import (
     CellType,
@@ -65,6 +64,11 @@ def test_gmshio():
 
 
 def test_pyvista():
+    import pyvista
+
+    # can't actually run this on headless CI
+    return
+
     # from https://docs.fenicsproject.org/dolfinx/main/python/demos/demo_pyvista.html
     msh = create_unit_square(MPI.COMM_WORLD, 12, 12, cell_type=CellType.quadrilateral)
     V = FunctionSpace(msh, ("Lagrange", 1))

--- a/recipe/test_dolfinx.py
+++ b/recipe/test_dolfinx.py
@@ -4,6 +4,13 @@ import dolfinx  # noqa
 import gmsh
 import numpy as np
 import pytest
+import pyvista
+from dolfinx.fem import Function, FunctionSpace
+from dolfinx.mesh import (
+    CellType,
+    create_unit_square,
+)
+from dolfinx import plot
 from dolfinx.cpp import common
 from dolfinx.io import gmshio
 from mpi4py import MPI
@@ -32,6 +39,14 @@ def test_has(feature):
     assert getattr(common, f"has_{feature}")
 
 
+def test_mesh():
+    # from https://docs.fenicsproject.org/dolfinx/main/python/demos/demo_pyvista.html
+    msh = create_unit_square(MPI.COMM_WORLD, 12, 12, cell_type=CellType.quadrilateral)
+    V = FunctionSpace(msh, ("Lagrange", 1))
+    u = Function(V, dtype=np.float64)
+    u.interpolate(lambda x: np.sin(np.pi * x[0]) * np.sin(2 * x[1] * np.pi))
+
+
 def test_gmshio():
     # meshing example taken from https://jsdokken.com/dolfinx-tutorial/chapter1/membrane_code.html
     gmsh.initialize()
@@ -47,3 +62,54 @@ def test_gmshio():
         gmsh.model, mesh_comm, gmsh_model_rank, gdim=2
     )
     gmsh.finalize()
+
+
+def test_pyvista():
+    # from https://docs.fenicsproject.org/dolfinx/main/python/demos/demo_pyvista.html
+    msh = create_unit_square(MPI.COMM_WORLD, 12, 12, cell_type=CellType.quadrilateral)
+    V = FunctionSpace(msh, ("Lagrange", 1))
+    u = Function(V, dtype=np.float64)
+    u.interpolate(lambda x: np.sin(np.pi * x[0]) * np.sin(2 * x[1] * np.pi))
+
+    # To visualize the function u, we create a VTK-compatible grid to
+    # values of u to
+    cells, types, x = plot.vtk_mesh(V)
+    grid = pyvista.UnstructuredGrid(cells, types, x)
+    grid.point_data["u"] = u.x.array
+
+    # The function "u" is set as the active scalar for the mesh, and
+    # warp in z-direction is set
+    grid.set_active_scalars("u")
+    warped = grid.warp_by_scalar()
+
+    # A plotting window is created with two sub-plots, one of the scalar
+    # values and the other of the mesh is warped by the scalar values in
+    # z-direction
+    subplotter = pyvista.Plotter(shape=(1, 2), off_screen=True)
+    subplotter.subplot(0, 0)
+    subplotter.add_text(
+        "Scalar contour field", font_size=14, color="black", position="upper_edge"
+    )
+    subplotter.add_mesh(grid, show_edges=True, show_scalar_bar=True)
+    subplotter.view_xy()
+
+    subplotter.subplot(0, 1)
+    subplotter.add_text(
+        "Warped function", position="upper_edge", font_size=14, color="black"
+    )
+    sargs = dict(
+        height=0.8,
+        width=0.1,
+        vertical=True,
+        position_x=0.05,
+        position_y=0.05,
+        fmt="%1.2e",
+        title_font_size=40,
+        color="black",
+        label_font_size=25,
+    )
+    subplotter.set_position([-3, 2.6, 0.3])
+    subplotter.set_focus([3, -1, -0.15])
+    subplotter.set_viewup([0, 0, 1])
+    subplotter.add_mesh(warped, show_edges=True, scalar_bar_args=sargs)
+    subplotter.screenshot("2D_function_warp.png")


### PR DESCRIPTION
make sure we're building a compatible package

no change in package, so no version bump

may need to wait an hour or two for updated vtk builds to propagate, as this is prompted by an update to pugixml in dolfinx, not yet in vtk.