### PR TITLE
depend on fenics-basix-pybind11-abi

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@
 {% set major_minor = version.rsplit(".", 1)[0] %}
 {% set ufl_version = "2023.1" %}
 
-{% set build = 5 %}
+{% set build = 6 %}
 {% if scalar == "real" %}
 {%   set build = build + 100 %}
 {% endif %}
@@ -120,6 +120,7 @@ outputs:
         - wheel
         - pybind11
         - pybind11-abi
+        - fenics-basix-pybind11-abi
         - mpi4py
         - petsc * {{ scalar }}_*
         - petsc4py


### PR DESCRIPTION
to ensure we're ABI compatible with basix at runtime (keeps compilers in sync)

tries to capture the C compiler version, which affects the pybind11 ABI

https://github.com/conda-forge/fenics-basix-feedstock/pull/10