### PR TITLE
finish 0.7 builds

### DIFF
--- a/recipe/annotations.patch
+++ b/recipe/annotations.patch
@@ -1,0 +1,26 @@
+From c9c4cf92f5347c75df2afba77648f57bbf79d68f Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Fri, 6 Oct 2023 12:13:06 +0200
+Subject: [PATCH] Missing from __future__ import annotations
+
+prevents failure to import in Python 3.8
+---
+ python/dolfinx/mesh.py | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/python/dolfinx/mesh.py b/python/dolfinx/mesh.py
+index 41922b1cbc..4f904a858f 100644
+--- a/python/dolfinx/mesh.py
++++ b/python/dolfinx/mesh.py
+@@ -5,6 +5,8 @@
+ # SPDX-License-Identifier:    LGPL-3.0-or-later
+ """Creation, refining and marking of meshes"""
+ 
++from __future__ import annotations
++
+ 
+ import typing
+ 
+-- 
+2.42.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,9 @@ package:
 source:
   url: https://github.com/fenics/dolfinx/archive/refs/tags/v{{ version }}{{ extra }}.tar.gz
   sha256: 9245e457a03c37983337456c0835263b7be083c5bf2978738b4e462ee5e83cde
+  patches:
+    - annotations.patch
+
 build:
   number: {{ build }}
   skip: true  # [win or py<=37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ source:
   sha256: 9245e457a03c37983337456c0835263b7be083c5bf2978738b4e462ee5e83cde
   patches:
     - annotations.patch
+    - test-functional.patch
 
 build:
   number: {{ build }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,7 +94,7 @@ outputs:
         - {{ compiler("cxx") }}
         - pkg-config
         - cmake
-        - catch2 2.*
+        - catch2 3.*
         - make
         - fenics-ffcx {{ major_minor }}.*
   - name: fenics-dolfinx

--- a/recipe/test-functional.patch
+++ b/recipe/test-functional.patch
@@ -1,0 +1,25 @@
+From 78d8755d2f1bfbf17e163404cd2c34d851ca73c5 Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Fri, 6 Oct 2023 13:29:05 +0200
+Subject: [PATCH] TST: add missing include <functional>
+
+needed for std::bind
+---
+ cpp/test/common/sort.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/cpp/test/common/sort.cpp b/cpp/test/common/sort.cpp
+index cf85eb276d..2236defcaf 100644
+--- a/cpp/test/common/sort.cpp
++++ b/cpp/test/common/sort.cpp
+@@ -4,6 +4,7 @@
+ //
+ // SPDX-License-Identifier:    LGPL-3.0-or-later
+ 
++#include <functional>
+ #include <catch2/catch_template_test_macros.hpp>
+ #include <catch2/catch_test_macros.hpp>
+ #include <catch2/generators/catch_generators.hpp>
+-- 
+2.42.0
+


### PR DESCRIPTION
I merged #44 because it turned green, but that's because azure failed to report its builds at all, which I didn't notice until too late.

So far, need to update the catch2 package version in the test env.