### PR TITLE
unpin for clang 16

### DIFF
--- a/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.8.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.8.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.8.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 hdf5:
 - 1.14.2
 libboost_devel:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,11 +6,6 @@ scalar:
   - real
   - complex
 
-c_compiler_version:  # [osx]
-  - 15  # [osx]
-cxx_compiler_version:  # [osx]
-  - 15  # [osx]
-
 pin_run_as_build:
   parmetis:
     max_pin: x.x


### PR DESCRIPTION
had to pin down to finish the last builds, but hopefully the 16 builds work now that dependencies have been updated.