### PR TITLE
petsc 3.22, hdf5 1.14.4

### DIFF
--- a/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpimpichpython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.12.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpimpichpython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.13.____cp313scalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpimpichpython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.13.____cp313scalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpiopenmpipython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.13.____cp313scalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpimpichpython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.12.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpimpichpython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.13.____cp313scalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpimpichpython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.13.____cp313scalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.13.____cp313scalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -39,9 +39,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -53,9 +53,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.12.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.12.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.13.____cp313scalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.13.____cp313scalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.12.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.13.____cp313scalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -33,9 +33,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -47,9 +47,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/migrations/hdf51144.yaml
+++ b/.ci_support/migrations/hdf51144.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for hdf5 1.14.4
+  kind: version
+  migration_number: 1
+hdf5:
+- 1.14.4
+migrator_ts: 1727986901.81392

--- a/.ci_support/migrations/petsc322.yaml
+++ b/.ci_support/migrations/petsc322.yaml
@@ -1,0 +1,14 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for petsc 3.22
+  kind: version
+  migration_number: 1
+migrator_ts: 1727625927.7062201
+petsc:
+- '3.22'
+slepc:
+- '3.22'
+petsc4py:
+- '3.22'
+slepc4py:
+- '3.22'

--- a/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpimpichpython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.12.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpimpichpython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.13.____cp313scalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpimpichpython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.13.____cp313scalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpiopenmpipython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.13.____cp313scalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpimpichpython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.12.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpimpichpython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.13.____cp313scalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpimpichpython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.13.____cp313scalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.13.____cp313scalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - complex
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:
@@ -35,9 +35,9 @@ mpich:
 openmpi:
 - '5'
 petsc:
-- '3.21'
+- '3.22'
 petsc4py:
-- '3.21'
+- '3.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -49,9 +49,9 @@ python:
 scalar:
 - real
 slepc:
-- '3.21'
+- '3.22'
 slepc4py:
-- '3.21'
+- '3.22'
 spdlog:
 - '1.13'
 target_platform:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - vs2022
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - vs2022
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - vs2022
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - vs2022
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - vs2022
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@
 {% set major_minor = version.rsplit(".", 1)[0] %}
 {% set ufl_version = "2024.2" %}
 
-{% set build = 2 %}
+{% set build = 3 %}
 
 {%- if scalar is not defined %}
 {%- set scalar = "" %}

--- a/recipe/test-dolfinx.bat
+++ b/recipe/test-dolfinx.bat
@@ -1,6 +1,8 @@
 setlocal EnableDelayedExpansion
 @echo on
 
+echo !PATH!
+
 pip check
 if errorlevel 1 exit 1
 


### PR DESCRIPTION
migrations aren't running automatically because there are only 1.14.4 builds of 3.22, so both need to be migrated together