### PR TITLE
hdf5 1.14.4 (excludes Windows)

### DIFF
--- a/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpimpichpython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.12.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpimpichpython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.12.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpimpichpython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.13.____cp313scalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpimpichpython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.13.____cp313scalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpimpichpython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.13.____cp313scalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpimpichpython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.13.____cp313scalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpiopenmpipython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.13.____cp313scalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpiopenmpipython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.13.____cp313scalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpimpichpython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.12.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpimpichpython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.12.____cpythonscalarreal.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpimpichpython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.13.____cp313scalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpimpichpython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.13.____cp313scalarcomplex.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpimpichpython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.13.____cp313scalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpimpichpython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.13.____cp313scalarreal.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.13.____cp313scalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.13.____cp313scalarreal.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -24,6 +24,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.12.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.12.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.12.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.12.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.13.____cp313scalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.13.____cp313scalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.13.____cp313scalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.13.____cp313scalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.12.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.12.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.13.____cp313scalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.13.____cp313scalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/migrations/fmt11.yaml
+++ b/.ci_support/migrations/fmt11.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for fmt 11
+  kind: version
+  migration_number: 1
+fmt:
+- '11'
+migrator_ts: 1720374637.828791

--- a/.ci_support/migrations/hdf51144.yaml
+++ b/.ci_support/migrations/hdf51144.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for hdf5 1.14.4
-  kind: version
-  migration_number: 1
-hdf5:
-- 1.14.4
-migrator_ts: 1727986901.81392

--- a/.ci_support/migrations/hdf51144.yaml
+++ b/.ci_support/migrations/hdf51144.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for hdf5 1.14.4
+  kind: version
+  migration_number: 1
+hdf5:
+- 1.14.4
+migrator_ts: 1727986901.81392

--- a/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.12.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpimpichpython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.12.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.13.____cp313scalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpimpichpython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.13.____cp313scalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.13.____cp313scalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpimpichpython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.13.____cp313scalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.13.____cp313scalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpiopenmpipython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.13.____cp313scalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.10.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.11.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.12.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.12.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpimpichpython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.12.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.13.____cp313scalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpimpichpython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.13.____cp313scalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.13.____cp313scalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpimpichpython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.13.____cp313scalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.12.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.12.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.13.____cp313scalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.13.____cp313scalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.13.____cp313scalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.13.____cp313scalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarcomplex.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,9 +17,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpythonscalarreal.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -11,7 +11,9 @@ cxx_compiler:
 fmt:
 - '11'
 hdf5:
-- 1.14.4
+- 1.14.3
+impi:
+- '2021.12'
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - vs2022
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -8,6 +8,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -11,7 +11,9 @@ cxx_compiler:
 fmt:
 - '11'
 hdf5:
-- 1.14.4
+- 1.14.3
+impi:
+- '2021.12'
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - vs2022
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -8,6 +8,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -11,7 +11,9 @@ cxx_compiler:
 fmt:
 - '11'
 hdf5:
-- 1.14.4
+- 1.14.3
+impi:
+- '2021.12'
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - vs2022
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -8,6 +8,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -11,7 +11,9 @@ cxx_compiler:
 fmt:
 - '11'
 hdf5:
-- 1.14.4
+- 1.14.3
+impi:
+- '2021.12'
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - vs2022
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -8,6 +8,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -11,7 +11,9 @@ cxx_compiler:
 fmt:
 - '11'
 hdf5:
-- 1.14.4
+- 1.14.3
+impi:
+- '2021.12'
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - vs2022
 hdf5:
-- 1.14.3
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -8,6 +8,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
+fmt:
+- '11'
 hdf5:
 - 1.14.4
 libboost_devel:

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -32,9 +32,6 @@ call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefi
     --channel conda-forge ^
     pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 if !errorlevel! neq 0 exit /b !errorlevel!
-echo Moving pkgs cache from %MAMBA_ROOT_PREFIX% to %MINIFORGE_HOME%
-move /Y "%MAMBA_ROOT_PREFIX%\pkgs" "%MINIFORGE_HOME%"
-if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%"
 del /S /Q "%MICROMAMBA_TMPDIR%"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ stages:
           echo "##vso[task.setvariable variable=log]$git_log"
         displayName: Obtain commit message
       - bash: echo "##vso[task.setvariable variable=RET]false"
-        condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))
+        condition: and(eq(variables['Build.Reason'], 'PullRequest'), or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]')))
         displayName: Skip build?
       - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
         name: result

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,9 +12,17 @@ scalar:
   - real  # [not win]
   - complex  # [not win]
 
+# FIXME: weird mpi crashes in #89
+# due to something in intel mpi update
+# from 2012.12 to 2012.13
+impi:
+  - "2021.12"  # [win]
+
+# manually apply hdf5 1.14.4 migration
+# except on Windows
+# can't use migrator, which overrides conda_build_config.yaml
 hdf5:
-  # FIXME: weird mpi crashes in #89
-  # due to something in intel mpi update
+  - 1.14.4  # [not win]
   - 1.14.3  # [win]
 
 pin_run_as_build:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,6 +12,11 @@ scalar:
   - real  # [not win]
   - complex  # [not win]
 
+hdf5:
+  # FIXME: weird mpi crashes in #89
+  # due to something in intel mpi update
+  - 1.14.3  # [win]
+
 pin_run_as_build:
   parmetis:
     max_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,6 +74,7 @@ outputs:
         - petsc * {{ scalar }}_*  # [not win]
         - pugixml
         - slepc  # [not win]
+        - fmt
         - spdlog
         - fenics-libbasix {{ major_minor }}.*
         - fenics-ufcx {{ major_minor }}.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -135,6 +135,9 @@ outputs:
         - petsc4py  # [not win]
         - slepc  # [not win]
         - slepc4py  # [not win]
+        # not actually a dependency of the Python part, but having it here
+        # seems to fix a solver error on libxml2's noicu build
+        - libboost-devel
       run:
         # code generation only needs c, not cxx
         - {{ compiler("c") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@
 {% set major_minor = version.rsplit(".", 1)[0] %}
 {% set ufl_version = "2024.2" %}
 
-{% set build = 4 %}
+{% set build = 5 %}
 
 {%- if scalar is not defined %}
 {%- set scalar = "" %}


### PR DESCRIPTION
closes #89 by holding back Windows to hdf5 1.14.3

we can isolate the Windows update as its own PR