### PR TITLE
Finish hdf5 1.14.4 (Windows)

### DIFF
--- a/.ci_support/migrations/hdf51144.yaml
+++ b/.ci_support/migrations/hdf51144.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for hdf5 1.14.4
+  kind: version
+  migration_number: 1
+hdf5:
+- 1.14.4
+migrator_ts: 1727986901.81392

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -11,9 +11,7 @@ cxx_compiler:
 fmt:
 - '11'
 hdf5:
-- 1.14.3
-impi:
-- '2021.12'
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -11,9 +11,7 @@ cxx_compiler:
 fmt:
 - '11'
 hdf5:
-- 1.14.3
-impi:
-- '2021.12'
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -11,9 +11,7 @@ cxx_compiler:
 fmt:
 - '11'
 hdf5:
-- 1.14.3
-impi:
-- '2021.12'
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -11,9 +11,7 @@ cxx_compiler:
 fmt:
 - '11'
 hdf5:
-- 1.14.3
-impi:
-- '2021.12'
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -11,9 +11,7 @@ cxx_compiler:
 fmt:
 - '11'
 hdf5:
-- 1.14.3
-impi:
-- '2021.12'
+- 1.14.4
 libboost_devel:
 - '1.86'
 libptscotch:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,21 +12,6 @@ scalar:
   - real  # [not win]
   - complex  # [not win]
 
-# FIXME: weird mpi crashes in #89
-# due to something in intel mpi update
-# from 2012.12 to 2012.13
-impi:
-  - "2021.12"  # [win]
-
-# manually apply hdf5 1.14.4 migration
-# except on Windows
-# can't use migrator, which overrides conda_build_config.yaml
-hdf5:
-  - 1.14.4  # [not win]
-  - 1.14.3  # [win]
-
 pin_run_as_build:
-  parmetis:
-    max_pin: x.x
   fenics-ufcx:
     max_pin: x.x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@
 {% set major_minor = version.rsplit(".", 1)[0] %}
 {% set ufl_version = "2024.2" %}
 
-{% set build = 5 %}
+{% set build = 6 %}
 
 {%- if scalar is not defined %}
 {%- set scalar = "" %}


### PR DESCRIPTION
impi 2021.13 seems broken, which is preventing this migration from completing, because there is not:

- 2021.12 builds of the new hdf5, nor
- 2021.13 builds with the older hdf5

so the only way to test impi 2021.13 is by upgrading hdf5. The failing tests don't involve hdf5 at all, though. It's extremely basic communicator setup that appears to fail.