### PR TITLE
Monthly version

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: fenics-dolfinx
-  version: 0.9.0-monthly
+  version: 0.9.0_monthly
   commit_sha: 5fcb988c5b0f46b8f9183bc844d8f533a2130d6a
   major_minor: ${{ (version | split('.'))[:2] | join('.') }}.*
   ufl_version: "2024.2.*"


### PR DESCRIPTION
The release cycles for dolfinx is typically 6+ months long. While the nightly docker build exists, I see value in having a development version packaged on conda. One use case is being able to benefit from some bug fixes that haven't been released in a patch release or testing new features before waiting for the next minor release.

The issue with conda is that automation is limited (compared to the nightly docker build).

A good compromise could be a monthly conda package?

Instead of getting the tarball from the GitHub release, we could get it from a specific commit on `main`.

There probably are a bunch of things that need fixing in this recipe and ideally it would be in a separate channel so that this is not treated as a stable version.

This is my proposal @minrk 😄 