### PR TITLE
avoid activating compilers in run dependencies

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,5 +9,5 @@ mpi:
   - impi  # [win]
 
 scalar:
-  - real  # [not win]
+  - real
   - complex  # [not win]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -9,7 +9,6 @@ context:
   abi3_python: "3.12"
   build_abi3: ${{ is_abi3 and match(python, abi3_python + ".*") }}
   skip_abi3: ${{ is_abi3 and match(python, ">=3.13") }}
-  c_compiler_name: ${{ c_compiler | default("bot")  + ("_impl" if linux else "") }}
 
   # nanobind abi:
   abi_version: 2.${{ nanobind_abi }}
@@ -184,7 +183,12 @@ outputs:
         # code generation only needs c, not cxx
         # get implementation, not full activation package
         # need unqualified 'gcc' to get `gcc` executable
-        - ${{ c_compiler | default("bot") }} >=${{ c_compiler_version | default("0") }}
+        - if: win
+          then:
+            # windows only has activation
+            - ${{ compiler("c") }}
+          else:
+            - ${{ c_compiler | default("bot") }} >=${{ c_compiler_version | default("0") }}
         - pkg-config
         - ${{ pin_subpackage("fenics-libdolfinx", exact=True) }}
         - cffi

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: fenics-dolfinx
   version: "0.10.0"
-  build: 4
+  build: 5
   major_minor: ${{ (version | split('.'))[:2] | join('.') }}.*
   ufl_version: "2025.2.*"
   # Python Stable ABI (SABI with nanobind requires 3.12)
@@ -9,6 +9,7 @@ context:
   abi3_python: "3.12"
   build_abi3: ${{ is_abi3 and match(python, abi3_python + ".*") }}
   skip_abi3: ${{ is_abi3 and match(python, ">=3.13") }}
+  c_compiler_name: ${{ c_compiler | default("bot")  + ("_impl" if linux else "") }}
 
   # nanobind abi:
   abi_version: 2.${{ nanobind_abi }}
@@ -181,7 +182,10 @@ outputs:
         - libboost-devel
       run:
         # code generation only needs c, not cxx
-        - ${{ compiler("c") }}
+        # get implementation, not activation
+        - if: not win
+          then:
+            - ${{ c_compiler_name }}_${{ target_platform }} >=${{ c_compiler_version|default("0") }}
         - pkg-config
         - ${{ pin_subpackage("fenics-libdolfinx", exact=True) }}
         - cffi

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -182,10 +182,9 @@ outputs:
         - libboost-devel
       run:
         # code generation only needs c, not cxx
-        # get implementation, not activation
-        - if: not win
-          then:
-            - ${{ c_compiler_name }}_${{ target_platform }} >=${{ c_compiler_version|default("0") }}
+        # get implementation, not full activation package
+        # need unqualified 'gcc' to get `gcc` executable
+        - ${{ c_compiler | default("bot") }} >=${{ c_compiler_version | default("0") }}
         - pkg-config
         - ${{ pin_subpackage("fenics-libdolfinx", exact=True) }}
         - cffi

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -225,10 +225,6 @@ outputs:
             - if: linux and aarch64
               then:
                 - libgl-devel
-                # seem to be getting nvpl on py310 for some reason
-                # which doesn't have sparse symbols
-                # 
-                - blas[build=openblas]
             - if: linux and target_platform != build_platform
               then:
                 # __glibc virtual package seems to resolve wrong on emulated linux

--- a/recipe/test-dolfinx.sh
+++ b/recipe/test-dolfinx.sh
@@ -9,10 +9,17 @@ export UCX_MEM_EVENTS=no
 
 TEST_DIR=$PWD
 
+# unset compiler flags, should still work
+unset CC
+unset CXX
+unset CFLAGS
+unset CXXFLAGS
+
 # disable clang availability check
 if [[ "$target_platform" =~ "osx" ]]; then
   export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 fi
+
 
 export PYTHONUNBUFFERED=1
 
@@ -52,4 +59,3 @@ if [[ "${target_platform}-${mpi}" == "linux-aarch64-openmpi" ]]; then
 else
   mpiexec -n 2 pytest -vs -k "$MPI_SELECTOR" $TESTS
 fi
-


### PR DESCRIPTION
avoids cross-compilation setting stacks of $CFLAGS for multiple targets, e.g. https://github.com/conda-forge/ctng-compiler-activation-feedstock/issues/74

builds should still work without these args (tests should confirm this, hopefully default $CC is correct from Python and -Wl,-rpath,$PREFIX/lib is found via pkg-config)